### PR TITLE
fix net/http Get

### DIFF
--- a/run/command.go
+++ b/run/command.go
@@ -640,31 +640,6 @@ func stdinToSrc() io.Reader {
 	return os.Stdin
 }
 `},
-		{
-			Type:    types.Typ[types.String],
-			Imports: []string{"io/ioutil", "log"},
-			Init:    "var src string",
-			ArgToSrc: `
-func argsToSrc(args []string) (string, []string) {
-	srcIdx := %d
-	src, err := ioutil.ReadFile(args[srcIdx])
-	if err != nil {
-		log.Fatal(err)
-	}
-	// Take out the src arg.
-	args = append(args[:srcIdx], args[srcIdx+1:]...)
-	return string(src), args
-}
-`,
-			StdinToSrc: `
-func stdinToSrc() string {
-	src, err := ioutil.ReadAll(os.Stdin)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return string(src)
-}
-`},
 	}
 }
 

--- a/run/command_test.go
+++ b/run/command_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -83,6 +85,34 @@ func TestJsonIndentStdin(t *testing.T) {
   "foo": "bar"
 }
 `[1:]
+	if out != expected {
+		t.Fatalf("Expected %q but got %q", expected, out)
+	}
+}
+
+func TestNetHTTPGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dir)
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	env := Env{
+		Stderr: stderr,
+		Stdout: stdout,
+	}
+	err = Run(Command{Package: "net/http", Function: "Get", Args: []string{ts.URL}, Cache: dir}, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	expected := "Hello, client\n\n"
 	if out != expected {
 		t.Fatalf("Expected %q but got %q", expected, out)
 	}


### PR DESCRIPTION
By adding string as a potential source value, we then try to use it
as a filename to open.  May need to rethink the whole auto-open filenames
or we won't be able to use string values.

Also added a test to verify net/http.Get works
