### PR TITLE
Fix uint64 args

### DIFF
--- a/run/_testfuncs/funcs.go
+++ b/run/_testfuncs/funcs.go
@@ -1,0 +1,7 @@
+package testfuncs
+
+// DoubleUint64 uses a uint64 as an argument for testing purposes. It returns 2x
+// the argument.
+func DoubleUint64(a uint64) uint64 {
+	return a * 2
+}

--- a/run/command.go
+++ b/run/command.go
@@ -885,7 +885,7 @@ func argToInt64(s string) int64 {
 			Assign:  "arg%d := argToUint64(args[%d])",
 			Imports: []string{"strconv", "log"},
 			Func: `
-func argToUint(s string) uint64 {
+func argToUint64(s string) uint64 {
 	u, err := strconv.ParseUint(s, 0, 64)
 	if err != nil {
 		log.Fatal(err)

--- a/run/command.go
+++ b/run/command.go
@@ -23,7 +23,7 @@ import (
 // doesn't matter, as long as it's different from earlier versions, but it's
 // nice to keep it in <semver>  <timestamp> format so that it has some human
 // meaning.
-const version = "0.9.1  2016-11-04 16:13:09.14020166"
+const version = "0.9.2  2017-06-17 23:02:43.896500743"
 
 // Used for type comparison.
 // These are ok to keep global since they're static.

--- a/run/command_test.go
+++ b/run/command_test.go
@@ -89,6 +89,39 @@ func TestMathSqrt(t *testing.T) {
 	}
 }
 
+// Tests uint64 parsing arguments and outputs.
+func TestUint64(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dir)
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	env := Env{
+		Stderr: stderr,
+		Stdout: stdout,
+	}
+	c := &Command{
+		Package:  "npf.io/gorram/run/_testfuncs",
+		Function: "DoubleUint64",
+		Args:     []string{"5"},
+		Cache:    dir,
+		Env:      env,
+	}
+	err = Run(c)
+	checkRunErr(err, c.script(), t)
+	out := stdout.String()
+	expected := "10\n"
+	if out != expected {
+		t.Errorf("Expected %q but got %q", expected, out)
+	}
+	if msg := stderr.String(); msg != "" {
+		t.Errorf("Expected no stderr output but got %q", msg)
+	}
+}
+
 // func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error
 // Tests stdin to []byte argument.
 // Tests a dst *bytes.Buffer with a []byte src.


### PR DESCRIPTION
copy code fix in #28 and adding tests.  Since there are no trivial functions in the stdlib that use uint64, added a testing package so we can implement anything we want.