### PR TITLE
Fix uint argument conversion

### DIFF
--- a/run/_testfuncs/funcs.go
+++ b/run/_testfuncs/funcs.go
@@ -5,3 +5,9 @@ package testfuncs
 func DoubleUint64(a uint64) uint64 {
 	return a * 2
 }
+
+// DoubleUint uses a uint as an argument for testing purposes. It returns 2x
+// the argument.
+func DoubleUint(a uint) uint {
+	return a * 2
+}

--- a/run/command.go
+++ b/run/command.go
@@ -833,7 +833,7 @@ func argToInt(s string) int {
 			Assign:  "arg%d := argToUint(args[%d])",
 			Imports: []string{"strconv", "log"},
 			Func: `
-func argToUint(s string) int {
+func argToUint(s string) uint {
 	u, err := strconv.ParseUint(s, 0, 0)
 	if err != nil {
 		log.Fatal(err)

--- a/run/command_test.go
+++ b/run/command_test.go
@@ -122,6 +122,39 @@ func TestUint64(t *testing.T) {
 	}
 }
 
+// Tests uint64 parsing arguments and outputs.
+func TestUint(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dir)
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	env := Env{
+		Stderr: stderr,
+		Stdout: stdout,
+	}
+	c := &Command{
+		Package:  "npf.io/gorram/run/_testfuncs",
+		Function: "DoubleUint",
+		Args:     []string{"5"},
+		Cache:    dir,
+		Env:      env,
+	}
+	err = Run(c)
+	checkRunErr(err, c.script(), t)
+	out := stdout.String()
+	expected := "10\n"
+	if out != expected {
+		t.Errorf("Expected %q but got %q", expected, out)
+	}
+	if msg := stderr.String(); msg != "" {
+		t.Errorf("Expected no stderr output but got %q", msg)
+	}
+}
+
 // func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error
 // Tests stdin to []byte argument.
 // Tests a dst *bytes.Buffer with a []byte src.


### PR DESCRIPTION
* Previous conversion had a typo, causing a function which returns a
uint to have an int return signature

* Adds a test which reproduces this issue (in previous commits of
course)