### PR TITLE
Remove monotonic clock from time.Now checks

### DIFF
--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -79,7 +79,16 @@ func TestTimeNow(t *testing.T) {
 	if !strings.HasPrefix(out, expected[:15]) {
 		t.Errorf("Expected ~%q but got %q", expected, out)
 	}
-	if !strings.HasSuffix(out, expected[len(expected)-9:]) {
+
+        // Sometimes time formatting includes the monotonic clock reading 
+	// appended to the end (but not always).  This will not be the same 
+	// between tests, so find the appropriate end point.
+	endOfString := len(expected)
+	mClockIdx := strings.Index(expected, "m=")
+	if mClockIdx!= -1 {
+		endOfString = mClockIdx
+	}
+	if !strings.HasSuffix(out[:endOfString], expected[endOfString-9:endOfString]) {
 		t.Errorf("Expected ~%q but got %q", expected, out)
 	}
 	if msg := stderr.String(); msg != "" {

--- a/run/command_test.go
+++ b/run/command_test.go
@@ -47,7 +47,16 @@ func TestTimeNow(t *testing.T) {
 	if !strings.HasPrefix(out, expected[:15]) {
 		t.Errorf("Expected ~%q but got %q", expected, out)
 	}
-	if !strings.HasSuffix(out, expected[len(expected)-9:]) {
+
+        // Sometimes time formatting includes the monotonic clock reading 
+	// appended to the end (but not always).  This will not be the same 
+	// between tests, so find the appropriate end point.
+	endOfString := len(expected)
+	mClockIdx := strings.Index(expected, "m=")
+	if mClockIdx!= -1 {
+		endOfString = mClockIdx
+	}
+	if !strings.HasSuffix(out[:endOfString], expected[endOfString-9:endOfString]) {
 		t.Errorf("Expected ~%q but got %q", expected, out)
 	}
 	if msg := stderr.String(); msg != "" {


### PR DESCRIPTION
time.Now may sometimes include the monotonic clock reading at the end of
it.  This will not be the same between runs, so make sure to remove it
before doing string comparisons.