### PR TITLE
Add functionality to handle variadics/slices (#7)

### DIFF
--- a/run/_testfuncs/funcs.go
+++ b/run/_testfuncs/funcs.go
@@ -1,7 +1,20 @@
 package testfuncs
 
+import "strconv"
+
 // DoubleUint64 uses a uint64 as an argument for testing purposes. It returns 2x
 // the argument.
 func DoubleUint64(a uint64) uint64 {
 	return a * 2
+}
+
+// MergeInts uses a variadic argument for testing purposes.  It also contains 
+// another argument of the same type to test for deduplication of converters.
+// It simply mashes all the arguments together into a giant string.
+func MergeInts(first int, ints ...int) string {
+	result := strconv.Itoa(first)
+	for _, i := range ints {
+		result += strconv.Itoa(i)
+	}
+	return result
 }

--- a/run/command_test.go
+++ b/run/command_test.go
@@ -122,6 +122,39 @@ func TestUint64(t *testing.T) {
 	}
 }
 
+// Tests Variadic parsing arguments and outputs.
+func TestVariadic(t *testing.T) {
+	t.Parallel()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dir)
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	env := Env{
+		Stderr: stderr,
+		Stdout: stdout,
+	}
+	c := &Command{
+		Package:  "npf.io/gorram/run/_testfuncs",
+		Function: "MergeInts",
+		Args:     []string{"5","6","7","8"},
+		Cache:    dir,
+		Env:      env,
+	}
+	err = Run(c)
+	checkRunErr(err, c.script(), t)
+	out := stdout.String()
+	expected := "5678\n"
+	if out != expected {
+		t.Errorf("Expected %q but got %q", expected, out)
+	}
+	if msg := stderr.String(); msg != "" {
+		t.Errorf("Expected no stderr output but got %q", msg)
+	}
+}
+
 // func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error
 // Tests stdin to []byte argument.
 // Tests a dst *bytes.Buffer with a []byte src.

--- a/run/template.go
+++ b/run/template.go
@@ -49,7 +49,7 @@ func main() {
 	{{.DstInit}}
 
 
-	{{.Results}}{{.PkgName}}.{{if .GlobalVar}}{{.GlobalVar}}.{{end}}{{.Func}}({{.Args}})
+	{{.Results}}{{.PkgName}}.{{if .GlobalVar}}{{.GlobalVar}}.{{end}}{{.Func}}({{.Args}}{{.Variadic}})
 	{{.ErrCheck}}
 	{{if ne .DstIdx -1}}
 	{{.DstToStdout}}


### PR DESCRIPTION
Note:  Right now the slice will grab every argument from where it is til
the end.  This is fine for variadics which must be the last parameter,
but slices don't have to be.  Need to implement error handling for
functions which contain a slice argument which is not last.

Alternatively, define alternate syntax for slices such as
"gorram pkg func {some, slice, parameter} other parameters"